### PR TITLE
Miscellanious code cleanup

### DIFF
--- a/qc2md.py
+++ b/qc2md.py
@@ -257,11 +257,7 @@ def write_markdown(
                             dialogue_events, entry.time
                         )
                         # If outputting to stdout, we don't want to bring up interface
-                        if (
-                            pick_refs
-                            and len(matches) > 1
-                            and output_filename is not None
-                        ):
+                        if pick_refs and len(matches) > 1 and md is not sys.stdout:
                             picks = pick_references(entry, matches)
                             if picks is None:
                                 # User interrupted picker (ctrl-C). Assume they want no more interaction

--- a/qc2md.py
+++ b/qc2md.py
@@ -384,7 +384,7 @@ def pick_references(
             )
             for i, option in enumerate(self.options):
                 yield Static(
-                    f"  {'* ' if i in self.selection else '  '}{'> ' if i == self.highlighted else '  '}{option.text}",
+                    f"  {'*' if i in self.selection else ' '} {'>' if i == self.highlighted else ' '} {option.text}",
                     id=f"option-{i}",
                 )
             yield Footer(show_command_palette=False)
@@ -393,10 +393,10 @@ def pick_references(
             self.update_widgets()
 
         def update_widgets(self):
-            for i, _ in enumerate(self.options):
+            for i, option in enumerate(self.options):
                 widget = self.query_one(f"#option-{i}", Static)
                 widget.update(
-                    f"  {'* ' if i in self.selection else '  '}{'> ' if i == self.highlighted else '  '}{self.options[i].text}"
+                    f"  {'*' if i in self.selection else ' '} {'>' if i == self.highlighted else ' '} {option.text}"
                 )
 
         async def action_up(self):
@@ -408,8 +408,8 @@ def pick_references(
             self.update_widgets()
 
         async def action_select(self):
+            # Toggle selection of the highlighted item
             (
-                # Toggle selection of the highlighted item
                 self.selection.remove(self.highlighted)
                 if (self.highlighted in self.selection)
                 else self.selection.append(self.highlighted)

--- a/qc2md.py
+++ b/qc2md.py
@@ -267,7 +267,7 @@ def write_markdown(
                 # Group != category when --chrono is supplied
                 if group != entry.category:
                     md.write(
-                        f"- [ ] [`{entry.time}` - **{entry.category}]: {entry.text}\n"
+                        f"- [ ] [`{entry.time}` - **{entry.category}**]: {entry.text}\n"
                     )
                 else:
                     md.write(f"- [ ] [`{entry.time}`]: {entry.text}\n")

--- a/qc2md.py
+++ b/qc2md.py
@@ -362,10 +362,10 @@ def pick_references(
             self.selection = []
 
         BINDINGS = [
-            Binding("Up", "up", "Move cursor up"),
-            Binding("Down", "down", "Move cursor down"),
+            Binding("up", "up", "Move cursor up"),
+            Binding("down", "down", "Move cursor down"),
             Binding("space", "select", "Select highlighted line"),
-            Binding("Enter", "accept", "Accept highlighted or selected line(s)"),
+            Binding("enter", "accept", "Accept highlighted or selected line(s)"),
         ]
 
         def compose(self) -> ComposeResult:

--- a/qc2md.py
+++ b/qc2md.py
@@ -297,14 +297,12 @@ def smart_open(filename: str | None):
     """
     if filename and filename != "-":
         fh = open(filename, mode="w", encoding="utf-8")
-    else:
-        fh = sys.stdout
-
-    try:
-        yield fh
-    finally:
-        if fh is not sys.stdout:
+        try:
+            yield fh
+        finally:
             fh.close()
+    else:
+        yield sys.stdout
 
 
 def main():

--- a/qc2md.py
+++ b/qc2md.py
@@ -104,7 +104,7 @@ def load_report(filename: str) -> tuple[str | None, list[str]]:
         tuple[str | None, list[str]]: Artifact filename if present, and list of raw lines
     """
     lines: list[str] = []
-    with open(filename, mode="r", encoding="utf-8") as file:
+    with open(filename, encoding="utf-8") as file:
         lines = file.readlines()
         # sample line in [FILE] section:
         # path      : /path/to/qc2md/test/blank.mkv
@@ -286,7 +286,7 @@ def write_markdown(
 @contextlib.contextmanager
 def smart_open(filename: str | None):
     """Custom open method for supporting stdout as a write destination
-    
+
     Based on https://stackoverflow.com/a/17603000/4611644, CC BY-SA 4.0
 
     Args:
@@ -335,10 +335,10 @@ def main():
     entries = categorize_entries(parse_report(lines), group_script_entries=args.chrono)
 
     write_markdown(
-        output_filename=output_filename,
-        entries=entries,
-        artifact_filename=artifact_filename,
-        githash=githash,
+        output_filename,
+        entries,
+        artifact_filename,
+        githash,
         dialogue_events=dialogue_events,
         include_references=args.refs or (dialogue_events is not None),
         ref_format=args.ref_format,

--- a/qc2md.py
+++ b/qc2md.py
@@ -101,13 +101,14 @@ def load_report(filename: str) -> tuple[str, list[str]]:
         filename (str): mpvQC report filename
 
     Returns:
-        tuple[str, list[str]]: Artifact filename and list of raw lines
+        tuple[str | None, list[str]]: Artifact filename if present, and list of raw lines
     """
     lines: list[str] = []
     with open(filename, mode="r", encoding="utf-8") as file:
         lines = file.readlines()
         artifact = next(
-            line.split("/")[-1].strip() for line in lines if line.startswith("path")
+            (line.split("/")[-1].strip() for line in lines if line.startswith("path")),
+            None,
         )
     lines = lines[lines.index("[DATA]\n") + 1 :]
 
@@ -207,7 +208,7 @@ def get_dialogue_lines_at_time(
 def write_markdown(
     output_filename: str | None,
     entries: dict[str, list[QCEntry]],
-    artifact_filename: str = None,
+    artifact_filename: str | None = None,
     githash: str = None,
     *,
     dialogue_events: list[ass.Dialogue] = None,

--- a/qc2md.py
+++ b/qc2md.py
@@ -251,7 +251,7 @@ def write_markdown(
                         )
                         if (
                             pick_refs
-                            and len(matches) != 1
+                            and len(matches) > 1
                             and output_filename is not None
                         ):
                             picks = pick_references(entry, matches)

--- a/qc2md.py
+++ b/qc2md.py
@@ -12,7 +12,6 @@ import git
 import sys
 import argparse
 import contextlib
-from typing import Dict
 from pathlib import Path
 from datetime import timedelta
 from dataclasses import dataclass
@@ -140,7 +139,7 @@ def parse_report(lines: list[str]) -> list[QCEntry]:
 
 def categorize_entries(
     entries: list[QCEntry], *, group_script_entries: bool = False
-) -> Dict[str, list[QCEntry]]:
+) -> dict[str, list[QCEntry]]:
     """Organize report entries into buckets based on their category
 
     Args:
@@ -148,9 +147,9 @@ def categorize_entries(
         group_script_entries (bool): Groups most categories under "Script". Defaults to False
 
     Returns:
-        Dict[str, list[QCEntry]]: Map between categories and entries
+        dict[str, list[QCEntry]]: Map between categories and entries
     """
-    data: Dict[str, list[QCEntry]] = {}
+    data: dict[str, list[QCEntry]] = {}
 
     for entry in entries:
         if group_script_entries:
@@ -207,7 +206,7 @@ def get_dialogue_lines_at_time(
 
 def write_markdown(
     output_filename: str | None,
-    entries: Dict[str, list[QCEntry]],
+    entries: dict[str, list[QCEntry]],
     artifact_filename: str = None,
     githash: str = None,
     *,
@@ -220,7 +219,7 @@ def write_markdown(
 
     Args:
         output_filename (str | None): Output filename for the markdown file, or None for stdout
-        entries (Dict[str, list[QCEntry]]): Map between categories and entries
+        entries (dict[str, list[QCEntry]]): Map between categories and entries
         artifact_filename (str, optional): Artifact filename. Defaults to None.
         githash (str, optional): Current git hash. Defaults to None.
         dialogue_events (list[ass.Dialogue], optional): Dialogue events. Defaults to None.

--- a/qc2md.py
+++ b/qc2md.py
@@ -94,7 +94,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_report(filename: str) -> tuple[str, list[str]]:
+def load_report(filename: str) -> tuple[str | None, list[str]]:
     """Load the mpvQC report file
 
     Args:
@@ -149,7 +149,7 @@ def categorize_entries(
 
     Args:
         entries (list[QCEntry]): Uncategorized list of report entries
-        group_script_entries (bool): Groups most categories under "Script". Defaults to False
+        group_script_entries (bool, optional): Groups most categories under "Script". Defaults to False
 
     Returns:
         dict[str, list[QCEntry]]: Map between categories and entries
@@ -215,9 +215,9 @@ def write_markdown(
     output_filename: str | None,
     entries: dict[str, list[QCEntry]],
     artifact_filename: str | None = None,
-    githash: str = None,
+    githash: str | None = None,
     *,
-    dialogue_events: list[ass.Dialogue] = None,
+    dialogue_events: list[ass.Dialogue] | None = None,
     include_references: bool = False,
     ref_format: RefFormat = RefFormat.FULL,
     pick_refs: bool = True,
@@ -232,7 +232,7 @@ def write_markdown(
         dialogue_events (list[ass.Dialogue], optional): Dialogue events. Defaults to None.
         include_references (bool, optional): Should references be added?. Defaults to False.
         ref_format (RefFormat, optional): Dialogue file reference formatting. Defaults to FULL.
-        pick_refs (bool, optional): Display a picker interfact if there are multiple matching refs. Defaults to True
+        pick_refs (bool, optional): Display a picker interface if there are multiple matching refs. Defaults to True
     """
     with smart_open(output_filename) as md:
         # Write the header if values are supplied
@@ -340,20 +340,20 @@ def main():
         artifact_filename=artifact_filename,
         githash=githash,
         dialogue_events=dialogue_events,
-        include_references=(args.refs or dialogue_events),
+        include_references=args.refs or (dialogue_events is not None),
         ref_format=args.ref_format,
         pick_refs=args.pick_refs,
     )
 
 
 def pick_references(
-    note: str, options: list[ass.Dialogue]
+    note: QCEntry, options: list[ass.Dialogue]
 ) -> list[ass.Dialogue] | None:
     """Display an interface for selecting the appropriate dialogue line(s)
     if there are multiple matches
 
     Args:
-        note (str): The note to match for
+        note (QCEntry): The note to match for
         options (list[ass.Dialogue]): List of matching dialogue lines
 
     Returns:
@@ -369,7 +369,7 @@ def pick_references(
             self.note = note
             self.options = options
             self.highlighted = 0
-            self.selection = []
+            self.selection: list[int] = []
 
         BINDINGS = [
             Binding("up", "up", "Move cursor up"),


### PR DESCRIPTION
Recommend squashing this.

- Use builtin dict rather than typing.Dict
- Avoid crashing when mpvQC doesn't output artifact path
- Correctly bold category when using --chrono
- Do not show picker for lines with 0 candidates
- Fix casing of TUI bindings
- Add minor comments
- Fix type annotations and docstrings
- Fix minor inconsistencies in code style
- Slightly clean up pick_references code style
- Adjust smart_open to condense logic
- Check directly if outputting to stdout