### PR TITLE
Add --auto-dialogue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Mandatory arguments to long options are mandatory for short options too.
 - `-r`, `--refs`: Add quotation blocks for line references above report entries. (Use `--dialogue` to include actual lines.)
 - `-c`, `--chrono`: Group most notes together in chronological order. The category will be added to each line. Some categories, like Typesetting, will remain separate.
 - `-d`, `--dialogue DIALOGUE`: ASS subtitle file to source references from, where appropriate. Implies `--refs`.
+  - `-D`, `--auto-dialogue`: Alternative to, and mutually exclusive with `-d`. Tries to detect a dialogue file in the same directory as the report file. Implies `--refs`.
 - `-f`, `--ref-format {full,text}`: How to format references sourced from the dialogue file. `full` includes the entire event definition, `text` includes just the text. Default: `full`
   - `-F` and `-T` are provided as shorthand to set `full` and `text` respectively
 - `--pick-refs`, `--no-pick-refs`: Enables or disables the reference picker. If there are multiple matches in the dialogue file, a picker is displayed to allow selection of the correct line(s). Default: enabled

--- a/qc2md.py
+++ b/qc2md.py
@@ -67,10 +67,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Group most notes together in chronological order",
     )
-    parser.add_argument(
+    dialogue = parser.add_mutually_exclusive_group()
+    dialogue.add_argument(
         "-d",
         "--dialogue",
         help="ASS subtitle file file to source references from, where appropriate. Implies --refs.",
+    )
+    dialogue.add_argument(
+        "-D",
+        "--auto-dialogue",
+        action="store_true",
+        help="Automatically try to detect dialogue file in same directory as report file. Implies --refs.",
     )
     parser.add_argument(
         "-f",
@@ -330,9 +337,16 @@ def main():
         )
     )
 
+    if args.auto_dialogue:
+        dialogue_path = next(
+            Path(report_filename).parent.glob("*[Dd]ialogue*.ass"), None
+        )
+    else:
+        dialogue_path = args.dialogue
+
     dialogue_events = (
-        load_dialogue_file(Path(args.dialogue))
-        if (args.dialogue and Path(args.dialogue).exists())
+        load_dialogue_file(Path(dialogue_path))
+        if (dialogue_path and Path(dialogue_path).exists())
         else None
     )
 


### PR DESCRIPTION
Mutually exclusive with --dialogue; instead automatically searches the directory containing the report file for any `*Dialogue*.ass` file.
